### PR TITLE
Fixed WCS's reference pixel, FITS pixels start at 1.

### DIFF
--- a/src/squeeze.c
+++ b/src/squeeze.c
@@ -1772,9 +1772,9 @@ int writeasfits(const char *file, double *image, int nwavr, long depth, long min
     printerror(status);
   if (fits_write_key_dbl(fptr, "CRVAL2", 0.0, 3, "Y-coordinate of ref pixel", &status))
     printerror(status);
-  if (fits_write_key_lng(fptr, "CRPIX1", naxes[0] / 2, "Ref pixel in X", &status))
+  if (fits_write_key_lng(fptr, "CRPIX1", naxes[0] / 2 + 1, "Ref pixel in X", &status))
     printerror(status);
-  if (fits_write_key_lng(fptr, "CRPIX2", naxes[1] / 2, "Ref pixel in Y", &status))
+  if (fits_write_key_lng(fptr, "CRPIX2", naxes[1] / 2 + 1, "Ref pixel in Y", &status))
     printerror(status);
   if (fits_write_key_str(fptr, "CTYPE1", "RA", "Name of X-coordinate", &status))
     printerror(status);


### PR DESCRIPTION
The reconstructed image of a point source based on complex visibilities only result in a single pixel shifted by (+1,+1). This is just a minor correction to the WCS definition in the output image fits header. See definition of `CRPIXj` in p. 31 of https://fits.gsfc.nasa.gov/standard40/fits_standard40aa-le.pdf.

Thank you for squeeze!